### PR TITLE
Fix syntax highlighting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ See [the docs](https://docs.rs/bisetmap/) for more details and example code.
 
 ## Examples
 
-```
+```rust
 use bisetmap::BisetMap;
 
 let subscriptions = BisetMap::new();


### PR DESCRIPTION
Before:
![before SS](https://user-images.githubusercontent.com/6709544/32618673-a54e5e9a-c578-11e7-8dce-ef6d2c3019be.png)

After:
![after SS](https://user-images.githubusercontent.com/6709544/32618690-af270dcc-c578-11e7-97ee-a7fe62ae861d.png)